### PR TITLE
Fix compilation error.  Usages of snprintf after reflex.h is #include…

### DIFF
--- a/src/member_names.cxx
+++ b/src/member_names.cxx
@@ -97,3 +97,7 @@ namespace reflex {
   } // namespace codegen
 
 } // namespace reflex
+
+#if _MSC_VER
+#undef snprintf
+#endif


### PR DESCRIPTION
…d fail to compile on Windows with error: error C2039: 'sprintf_s': is not a member of 'std'.  This occurs because member_names.cxx #defines snprintf for its own internal use.  Subsequent uses of snprintf get this defintion instead of the definition from stdio.h.  Solution - #undef snprintf at the end of member_names.cxx.